### PR TITLE
[Refactor] Remove jwt verify callback on User Controller

### DIFF
--- a/src/api/users/controller.js
+++ b/src/api/users/controller.js
@@ -168,26 +168,27 @@ exports.login = async (req, res) => {
             throw new CustomError('Akun anda belum aktif, silahkan mengaktifkan akun melalui link yang telah diberikan di email Anda');
         }
 
-        const checkTokenIsValid = jwt.verify(selectUser.token, process.env.TOKEN_SECRET, (err, decoded) => {
-            if( err ) {
-                const token = jwt.sign({ id: selectUser._id, username: selectUser.username }, process.env.TOKEN_SECRET, { expiresIn: '24h' });
-                selectUser.token = token;
-                selectUser.save();
-
-                return res.status(200).send({
-                    status: 'success',
-                    message: 'Login berhasil',
-                    token
-                }); 
-            } else {
-                return res.status(200).send({
-                    status: 'success',
-                    message: 'Login berhasil',
-                    token: selectUser.token
-                });
-            }
-        });
         
+        try {
+            const checkTokenIsValid = jwt.verify(selectUser.token, process.env.TOKEN_SECRET);
+
+            return res.status(200).send({
+                status: 'success',
+                message: 'Login berhasil',
+                token: selectUser.token
+            });
+        } catch(err) {
+            //  Token tidak valid
+            const token = jwt.sign({ id: selectUser._id, username: selectUser.username }, process.env.TOKEN_SECRET, { expiresIn: '24h' });
+            selectUser.token = token;
+            selectUser.save();
+
+            return res.status(200).send({
+                status: 'success',
+                message: 'Login berhasil',
+                token
+            }); 
+        }
     } catch (error) {
         return res.status(error.statusCode || 500).send({
             status: 'failed',


### PR DESCRIPTION
Sesuai dengan dokumentasi pada [jsonwebtoken](https://www.npmjs.com/package/jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback).
jika **jwt.verify** tidak diberikan parameter callback, apabila token valid maka akan mereturn valid,
Apa Bila tidak valid maka akan mereturn error, oleh karena itu saya menggunakan double try & catch. 